### PR TITLE
コンピューター思考中に別のプレイヤーのモード切り替えを行うと、その度に思考時間が2秒伸び続けてる挙動となっていたので、コンピューター入力待…

### DIFF
--- a/Reversi/Model/AppState/ComputerInputWaitingState.swift
+++ b/Reversi/Model/AppState/ComputerInputWaitingState.swift
@@ -88,7 +88,9 @@ class ComputerInputWaitingState<Repository: ReversiGameRepository, Dispatcher: D
             dispatcher: dispatcher,
             output: output
         )
-        return factory.make(from: game)
+        let newState = factory.make(from: game)
+        if newState is Self { return self }
+        return newState
     }
 
     func reset() throws -> AppState {


### PR DESCRIPTION
コンピューター思考中に別のプレイヤーのモード切り替えを行うと、その度に思考時間が2秒伸び続けてる挙動となっていたバグを修正